### PR TITLE
Fixes the inability to delete photos in Android

### DIFF
--- a/src/hooks/usePhotoGallery.ts
+++ b/src/hooks/usePhotoGallery.ts
@@ -107,8 +107,7 @@ export function usePhotoGallery() {
 
         // delete photo from file system
         const fileDeleted = await deleteFile({
-          path: photo.filepath,
-          directory: FilesystemDirectory.Data
+          path: photo.filepath
         });
       }
 


### PR DESCRIPTION
It was unnecessarily pointing to a system directory where we already had the full path available.